### PR TITLE
Set specific postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
             - sail
 
     wallet-api-db:
-        image: postgres
+        image: postgres:17
         healthcheck:
             test: [ "CMD", "pg_isready", "-q", "-U", "${WALTID_DB_USERNAME}" ]
             interval: 5s


### PR DESCRIPTION
When there is no version set, the latest version that you have pulled locally is used. The db volume is persistent and if the postgres version changes you will see an error that the data in the volume is not compatible with the postgres version. 